### PR TITLE
Fix comeout 11 test dice

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -83,11 +83,11 @@ tap.test('comeout', function (suite) {
       isComeOut: true
     }
 
-    const result = lib.shoot(handState, [7, 4])
+    const result = lib.shoot(handState, [6, 5])
 
     t.equal(result.result, 'comeout win')
-    t.equal(result.die1, 4)
-    t.equal(result.die2, 7)
+    t.equal(result.die1, 5)
+    t.equal(result.die2, 6)
     t.equal(result.diceSum, 11)
     t.equal(result.isComeOut, true)
 


### PR DESCRIPTION
## Summary
- change dice for the comeout 11 test to `[6, 5]`
- update expected values for sorted dice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849f59a3a0883238d130ec0202ee3d4