### PR TITLE
Add customizable table rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ Hand: 1
 └─────────┴──────┴──────┴─────────┴─────────────┴───────────┴───────┘
 ```
 
+## table rules
+
+`playHand` accepts a `rules` object that controls minimum bets and odds limits.
+You can now also customize which numbers win or lose on the come out roll.
+
+```js
+const rules = {
+  minBet: 5,
+  maxOddsMultiple: { /* ... */ },
+  comeOutWin: [7, 11],
+  comeOutLoss: [2, 3, 12] // default
+}
+```
+
 ## what? why?
 
 I like to play craps sometimes. I have a handful of strategies I like to play. It is time consuming to play in an app. I'd like to play 5, 50, 500 hands very fast using various strategies. Which strategies are best is well understood, the variability comes in with how aggressive your strategies are and the level of risk you assume at any given moment. And of course the dice outcomes and their deviation from long term probabilities and how they interact with the strategies you employ is the fun part. This simulator lets me scratch my craps itch very quickly.  

--- a/index.js
+++ b/index.js
@@ -7,7 +7,13 @@ function rollD6 () {
   return 1 + Math.floor(Math.random() * 6)
 }
 
-function shoot (before, dice) {
+const defaultRules = {
+  comeOutLoss: [2, 3, 12],
+  comeOutWin: [7, 11]
+}
+
+function shoot (before, dice, rules = defaultRules) {
+  rules = Object.assign({}, defaultRules, rules)
   const sortedDice = dice.sort()
 
   const after = {
@@ -19,10 +25,10 @@ function shoot (before, dice) {
   // game logic based on: https://github.com/tphummel/dice-collector/blob/master/PyTom/Dice/logic.py
 
   if (before.isComeOut) {
-    if ([2, 3, 12].indexOf(after.diceSum) !== -1) {
+    if (rules.comeOutLoss.includes(after.diceSum)) {
       after.result = 'comeout loss'
       after.isComeOut = true
-    } else if ([7, 11].indexOf(after.diceSum) !== -1) {
+    } else if (rules.comeOutWin.includes(after.diceSum)) {
       after.result = 'comeout win'
       after.isComeOut = true
     } else {
@@ -65,7 +71,8 @@ function playHand ({ rules, bettingStrategy, roll = rollD6 }) {
 
     hand = shoot(
       hand,
-      [roll(), roll()]
+      [roll(), roll()],
+      rules
     )
 
     if (process.env.DEBUG) console.log(`[roll] ${hand.result} (${hand.diceSum})`)
@@ -88,5 +95,6 @@ module.exports = {
   rollD6,
   shoot,
   playHand,
-  betting
+  betting,
+  defaultRules
 }

--- a/index.test.js
+++ b/index.test.js
@@ -199,6 +199,23 @@ tap.test('comeout', function (suite) {
   suite.end()
 })
 
+tap.test('comeout with custom rules', (t) => {
+  const handState = {
+    isComeOut: true
+  }
+
+  const rules = {
+    comeOutLoss: [2, 3],
+    comeOutWin: [7, 11, 12]
+  }
+
+  const result = lib.shoot(handState, [6, 6], rules)
+  t.equal(result.result, 'comeout win')
+  t.equal(result.isComeOut, true)
+
+  t.end()
+})
+
 tap.test('point set', (suite) => {
   suite.test('neutral 2', (t) => {
     const handState = {


### PR DESCRIPTION
## Summary
- allow specifying custom comeout win/loss numbers
- expose `defaultRules`
- document new table rule options
- test custom rule behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c5018918483238dc213e9045f5d13