### PR TITLE
Add pass line min-odds strategy

### DIFF
--- a/betting.js
+++ b/betting.js
@@ -35,7 +35,44 @@ function minPassLineMaxOdds (opts) {
   return bets
 }
 
+function minPassLineMinOdds (opts) {
+  const bets = minPassLineOnly(opts)
+  const { rules, hand } = opts
+
+  if (process.env.DEBUG) console.log(`[decision] make a new pass odds bet?: ${!hand.isComeOut} && ${!bets?.pass?.odds}`)
+
+  if (hand.isComeOut === false && !bets?.pass?.odds) {
+    const lineAmount = bets.pass.line.amount
+    const maxAllowed = rules.maxOddsMultiple[hand.point] * lineAmount
+    let oddsAmount = lineAmount
+
+    if (hand.point === 6 || hand.point === 8) {
+      oddsAmount = Math.ceil(oddsAmount / 5) * 5
+    } else if (hand.point === 5 || hand.point === 9) {
+      if (oddsAmount % 2 === 1) oddsAmount += 1
+    }
+
+    if (oddsAmount > maxAllowed) {
+      if (hand.point === 6 || hand.point === 8) {
+        oddsAmount = Math.floor(maxAllowed / 5) * 5
+      } else if (hand.point === 5 || hand.point === 9) {
+        oddsAmount = Math.floor(maxAllowed / 2) * 2
+      } else {
+        oddsAmount = maxAllowed
+      }
+    }
+
+    bets.pass.odds = {
+      amount: oddsAmount
+    }
+    bets.new += oddsAmount
+  }
+
+  return bets
+}
+
 module.exports = {
   minPassLineOnly,
-  minPassLineMaxOdds
+  minPassLineMaxOdds,
+  minPassLineMinOdds
 }

--- a/betting.test.js
+++ b/betting.test.js
@@ -209,3 +209,110 @@ tap.test('minPassLineMaxOdds: continue existing bet', (t) => {
 
   t.end()
 })
+
+tap.test('minPassLineMinOdds: point 5 requires even odds', (t) => {
+  const rules = {
+    minBet: 5,
+    maxOddsMultiple: {
+      4: 3,
+      5: 4,
+      6: 5,
+      8: 5,
+      9: 4,
+      10: 3
+    }
+  }
+
+  const hand = {
+    isComeOut: false,
+    result: 'point set',
+    point: 5
+  }
+
+  const bets = {
+    pass: {
+      line: {
+        amount: 5,
+        isContract: true
+      }
+    }
+  }
+
+  const updatedBets = lib.minPassLineMinOdds({ rules, bets, hand })
+  t.equal(updatedBets.pass.odds.amount, 6)
+  t.equal(updatedBets.new, 6)
+  t.end()
+})
+
+tap.test('minPassLineMinOdds: point 6 multiple of five', (t) => {
+  const rules = {
+    minBet: 5,
+    maxOddsMultiple: {
+      4: 3,
+      5: 4,
+      6: 5,
+      8: 5,
+      9: 4,
+      10: 3
+    }
+  }
+
+  const hand = {
+    isComeOut: false,
+    result: 'point set',
+    point: 6
+  }
+
+  const bets = {
+    pass: {
+      line: {
+        amount: 5,
+        isContract: true
+      }
+    }
+  }
+
+  const updatedBets = lib.minPassLineMinOdds({ rules, bets, hand })
+  t.equal(updatedBets.pass.odds.amount, 5)
+  t.equal(updatedBets.new, 5)
+  t.end()
+})
+
+tap.test('minPassLineMinOdds: continue existing bet', (t) => {
+  const rules = {
+    minBet: 5,
+    maxOddsMultiple: {
+      4: 3,
+      5: 4,
+      6: 5,
+      8: 5,
+      9: 4,
+      10: 3
+    }
+  }
+
+  const hand = {
+    isComeOut: false,
+    result: 'neutral',
+    point: 6,
+    diceSum: 4
+  }
+
+  const bets = {
+    pass: {
+      line: {
+        amount: 5,
+        isContract: true
+      },
+      odds: {
+        amount: 5,
+        isContract: false
+      }
+    }
+  }
+
+  const updatedBets = lib.minPassLineMinOdds({ rules, bets, hand })
+  t.equal(updatedBets.pass.odds.amount, bets.pass.odds.amount)
+  t.notOk(updatedBets.new)
+  t.end()
+})

--- a/index.test.js
+++ b/index.test.js
@@ -496,3 +496,46 @@ tap.test('integration: minPassLineMaxOdds, one hand with everything', (suite) =>
 
   suite.end()
 })
+
+tap.test('integration: minPassLineMinOdds, one hand with everything', (suite) => {
+  let rollCount = -1
+  const fixedRolls = [
+    4, 3, // comeout win
+    5, 6, // comeout win
+    1, 1, // comeout loss
+    1, 2, // comeout loss
+    6, 6, // comeout loss
+    3, 3, // point set
+    4, 1, // neutral
+    2, 4, // point win
+    4, 4, // point set
+    3, 4 // seven out
+  ]
+
+  function testRoll () {
+    rollCount++
+    if (!fixedRolls[rollCount]) {
+      console.log('falsy return from fixed dice')
+      process.exit(1)
+    }
+    return fixedRolls[rollCount]
+  }
+
+  const rules = {
+    minBet: 5,
+    maxOddsMultiple: {
+      4: 3,
+      5: 4,
+      6: 5,
+      8: 5,
+      9: 4,
+      10: 3
+    }
+  }
+
+  const hand = lib.playHand({ rules, roll: testRoll, bettingStrategy: betting.minPassLineMinOdds })
+  suite.ok(Array.isArray(hand.history))
+  suite.equal(hand.balance, -4)
+
+  suite.end()
+})


### PR DESCRIPTION
## Summary
- implement `minPassLineMinOdds` betting strategy
- test `minPassLineMinOdds` strategy
- integrate strategy in end-to-end tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d859536d083238c72f2412dececb6