### PR TITLE
feat: keep place bets regardless of point

### DIFF
--- a/betting.js
+++ b/betting.js
@@ -35,7 +35,29 @@ function minPassLineMaxOdds (opts) {
   return bets
 }
 
+function placeSixEight (opts) {
+  const { rules, bets: existingBets = {}, hand } = opts
+  const bets = Object.assign({ new: 0 }, existingBets)
+
+  if (hand.isComeOut) return bets
+
+  bets.place = bets.place || {}
+
+  if (!bets.place.six) {
+    bets.place.six = { amount: rules.minBet }
+    bets.new += bets.place.six.amount
+  }
+
+  if (!bets.place.eight) {
+    bets.place.eight = { amount: rules.minBet }
+    bets.new += bets.place.eight.amount
+  }
+
+  return bets
+}
+
 module.exports = {
   minPassLineOnly,
-  minPassLineMaxOdds
+  minPassLineMaxOdds,
+  placeSixEight
 }

--- a/betting.test.js
+++ b/betting.test.js
@@ -209,3 +209,71 @@ tap.test('minPassLineMaxOdds: continue existing bet', (t) => {
 
   t.end()
 })
+
+tap.test('placeSixEight: make new place bets after point set', (t) => {
+  const rules = {
+    minBet: 6
+  }
+
+  const hand = {
+    isComeOut: false,
+    point: 5
+  }
+
+  const updatedBets = lib.placeSixEight({ rules, hand })
+
+  t.equal(updatedBets.place.six.amount, rules.minBet)
+  t.equal(updatedBets.place.eight.amount, rules.minBet)
+  t.equal(updatedBets.new, rules.minBet * 2)
+
+  t.end()
+})
+
+tap.test('placeSixEight: no new bets on comeout', (t) => {
+  const rules = { minBet: 6 }
+  const hand = { isComeOut: true }
+
+  const updatedBets = lib.placeSixEight({ rules, hand })
+
+  t.notOk(updatedBets.place)
+  t.notOk(updatedBets.new)
+
+  t.end()
+})
+
+tap.test('placeSixEight: existing bets remain', (t) => {
+  const rules = { minBet: 6 }
+  const hand = { isComeOut: false, point: 8 }
+
+  const bets = { place: { six: { amount: 6 }, eight: { amount: 6 } } }
+
+  const updatedBets = lib.placeSixEight({ rules, bets, hand })
+
+  t.equal(updatedBets.place.six.amount, 6)
+  t.equal(updatedBets.place.eight.amount, 6)
+  t.notOk(updatedBets.new)
+
+  t.end()
+})
+
+tap.test('placeSixEight: place bets even when point is 6 or 8', (t) => {
+  const rules = { minBet: 6 }
+  const handSix = { isComeOut: false, point: 6 }
+
+  const firstBets = lib.placeSixEight({ rules, hand: handSix })
+
+  t.equal(firstBets.place.six.amount, rules.minBet)
+  t.equal(firstBets.place.eight.amount, rules.minBet)
+  t.equal(firstBets.new, rules.minBet * 2)
+
+  delete firstBets.new
+
+  const handEight = { isComeOut: false, point: 8 }
+  const bets = lib.placeSixEight({ rules, bets: firstBets, hand: handEight })
+
+  t.equal(bets.place.six.amount, rules.minBet)
+  t.equal(bets.place.eight.amount, rules.minBet)
+  t.notOk(bets.new)
+
+  t.end()
+})

--- a/hands.js
+++ b/hands.js
@@ -1,13 +1,13 @@
 'use strict'
 
 const { playHand } = require('./index.js')
-const { minPassLineMaxOdds } = require('./betting.js')
+const { placeSixEight } = require('./betting.js')
 
 const numHands = parseInt(process.argv.slice(2)[0], 10)
 const showDetail = process.argv.slice(2)[1]
 
 console.log(`Simulating ${numHands} Craps Hand(s)`)
-console.log('Using betting strategy: minPassLineMaxOdds')
+console.log('Using betting strategy: placeSixEight')
 
 const summaryTemplate = {
   balance: 0,
@@ -51,7 +51,7 @@ const rules = {
 console.log(`[table rules] minimum bet: $${rules.minBet}`)
 
 for (let i = 0; i < numHands; i++) {
-  const hand = playHand({ rules, bettingStrategy: minPassLineMaxOdds })
+  const hand = playHand({ rules, bettingStrategy: placeSixEight })
   hand.summary = Object.assign({}, summaryTemplate)
 
   sessionSummary.balance += hand.balance

--- a/settle.js
+++ b/settle.js
@@ -49,6 +49,40 @@ function passOdds ({ bets, hand, rules }) {
   return { payout, bets }
 }
 
+function placeBet ({ bets, hand, placeNumber }) {
+  const label = placeNumber === 6 ? 'six' : placeNumber === 8 ? 'eight' : String(placeNumber)
+
+  if (!bets?.place?.[label]) return { bets }
+  if (hand.isComeOut && hand.result !== 'seven out') return { bets }
+  if (hand.result === 'point set') return { bets }
+
+  if (hand.diceSum === 7) {
+    delete bets.place[label]
+    if (Object.keys(bets.place).length === 0) delete bets.place
+    return { bets }
+  }
+
+  if (hand.diceSum === placeNumber) {
+    const payout = {
+      type: `place ${placeNumber} win`,
+      principal: 0,
+      profit: bets.place[label].amount * (7 / 6)
+    }
+
+    return { payout, bets }
+  }
+
+  return { bets }
+}
+
+function placeSix (opts) {
+  return placeBet({ ...opts, placeNumber: 6 })
+}
+
+function placeEight (opts) {
+  return placeBet({ ...opts, placeNumber: 8 })
+}
+
 function all ({ bets, hand, rules }) {
   const payouts = []
 
@@ -61,6 +95,16 @@ function all ({ bets, hand, rules }) {
 
   bets = passOddsResult.bets
   payouts.push(passOddsResult.payout)
+
+  const placeSixResult = placeSix({ bets, hand })
+
+  bets = placeSixResult.bets
+  payouts.push(placeSixResult.payout)
+
+  const placeEightResult = placeEight({ bets, hand })
+
+  bets = placeEightResult.bets
+  payouts.push(placeEightResult.payout)
 
   bets.payouts = payouts.reduce((memo, payout) => {
     if (!payout) return memo
@@ -83,5 +127,8 @@ function all ({ bets, hand, rules }) {
 module.exports = {
   passLine,
   passOdds,
+  placeBet,
+  placeSix,
+  placeEight,
   all
 }

--- a/settle.test.js
+++ b/settle.test.js
@@ -385,3 +385,114 @@ tap.test('all: pass line win', (t) => {
 
   t.end()
 })
+
+tap.test('placeSix: win', (t) => {
+  const bets = { place: { six: { amount: 6 } } }
+
+  const hand = {
+    result: 'neutral',
+    isComeOut: false,
+    diceSum: 6
+  }
+
+  const result = settle.placeSix({ bets, hand })
+
+  t.equal(result.payout.type, 'place 6 win')
+  t.equal(result.payout.profit, 7)
+  t.equal(result.payout.principal, 0)
+  t.equal(result.bets.place.six.amount, 6)
+
+  t.end()
+})
+
+tap.test('placeEight: win', (t) => {
+  const bets = { place: { eight: { amount: 6 } } }
+
+  const hand = {
+    result: 'neutral',
+    isComeOut: false,
+    diceSum: 8
+  }
+
+  const result = settle.placeEight({ bets, hand })
+
+  t.equal(result.payout.type, 'place 8 win')
+  t.equal(result.payout.profit, 7)
+  t.equal(result.payout.principal, 0)
+  t.equal(result.bets.place.eight.amount, 6)
+
+  t.end()
+})
+
+tap.test('place bets: seven out removes bets', (t) => {
+  const bets = { place: { six: { amount: 6 }, eight: { amount: 6 } } }
+
+  const hand = {
+    result: 'seven out',
+    isComeOut: true,
+    diceSum: 7
+  }
+
+  const settled = settle.all({ bets, hand })
+
+  t.notOk(settled.place)
+  t.equal(settled.payouts.total, 0)
+
+  t.end()
+})
+
+tap.test('place bets: no action on comeout roll', (t) => {
+  const bets = { place: { six: { amount: 6 }, eight: { amount: 6 } } }
+
+  const hand = {
+    result: 'comeout win',
+    isComeOut: true,
+    diceSum: 7
+  }
+
+  const settled = settle.all({ bets, hand })
+
+  t.equal(settled.place.six.amount, 6)
+  t.equal(settled.place.eight.amount, 6)
+  t.equal(settled.payouts.total, 0)
+
+  t.end()
+})
+
+tap.test('place bet on 6 persists when point is 6', (t) => {
+  const bets = { place: { six: { amount: 6 }, eight: { amount: 6 } } }
+
+  const hand = {
+    result: 'point set',
+    isComeOut: false,
+    diceSum: 6,
+    point: 6
+  }
+
+  const settled = settle.all({ bets, hand })
+
+  t.equal(settled.place.six.amount, 6)
+  t.equal(settled.place.eight.amount, 6)
+  t.equal(settled.payouts.total, 0)
+
+  t.end()
+})
+
+tap.test('place bet on 8 persists when point is 8', (t) => {
+  const bets = { place: { six: { amount: 6 }, eight: { amount: 6 } } }
+
+  const hand = {
+    result: 'point set',
+    isComeOut: false,
+    diceSum: 8,
+    point: 8
+  }
+
+  const settled = settle.all({ bets, hand })
+
+  t.equal(settled.place.six.amount, 6)
+  t.equal(settled.place.eight.amount, 6)
+  t.equal(settled.payouts.total, 0)
+
+  t.end()
+})


### PR DESCRIPTION
## Summary
- keep place bets working even when the point is six or eight
- update settlement so place bets ignore point setting
- adjust unit tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d737939f8832387d7b869ccd895ed