### PR TITLE
Ensure place bets divisible by six

### DIFF
--- a/betting.js
+++ b/betting.js
@@ -43,13 +43,15 @@ function placeSixEight (opts) {
 
   bets.place = bets.place || {}
 
+  const placeAmount = Math.ceil(rules.minBet / 6) * 6
+
   if (!bets.place.six) {
-    bets.place.six = { amount: rules.minBet }
+    bets.place.six = { amount: placeAmount }
     bets.new += bets.place.six.amount
   }
 
   if (!bets.place.eight) {
-    bets.place.eight = { amount: rules.minBet }
+    bets.place.eight = { amount: placeAmount }
     bets.new += bets.place.eight.amount
   }
 

--- a/betting.test.js
+++ b/betting.test.js
@@ -277,3 +277,16 @@ tap.test('placeSixEight: place bets even when point is 6 or 8', (t) => {
 
   t.end()
 })
+
+tap.test('placeSixEight: bet rounds up to multiple of six', (t) => {
+  const rules = { minBet: 5 }
+  const hand = { isComeOut: false, point: 5 }
+
+  const updatedBets = lib.placeSixEight({ rules, hand })
+
+  t.equal(updatedBets.place.six.amount, 6)
+  t.equal(updatedBets.place.eight.amount, 6)
+  t.equal(updatedBets.new, 12)
+
+  t.end()
+})


### PR DESCRIPTION
## Summary
- adjust place6/8 strategy to round bet up to multiple of six
- test that bets round up for odd table mins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f08fe4e748323ad2cbff53f15dc35