### PR TITLE
Add place bet result tracking

### DIFF
--- a/hands.js
+++ b/hands.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { playHand } = require('./index.js')
-const { placeSixEight, minPassLineMaxOddsPlaceSixEight } = require('./betting.js')
+const { minPassLineMaxOddsPlaceSixEight } = require('./betting.js')
 
 const numHands = parseInt(process.argv.slice(2)[0], 10)
 const showDetail = process.argv.slice(2)[1]
@@ -18,6 +18,10 @@ const summaryTemplate = {
   comeOutLosses: 0,
   netComeOutWins: 0,
   neutrals: 0,
+  placeSixWins: 0,
+  placeSixLosses: 0,
+  placeEightWins: 0,
+  placeEightLosses: 0,
   dist: {
     2: { ct: 0, prob: 1 / 36 },
     3: { ct: 0, prob: 2 / 36 },
@@ -87,6 +91,29 @@ for (let i = 0; i < numHands; i++) {
         memo.netComeOutWins--
         hand.summary.netComeOutWins--
         break
+    }
+
+    if (Array.isArray(roll.payouts)) {
+      roll.payouts.forEach(p => {
+        if (p.type === 'place 6 win') {
+          memo.placeSixWins++
+          hand.summary.placeSixWins++
+        } else if (p.type === 'place 8 win') {
+          memo.placeEightWins++
+          hand.summary.placeEightWins++
+        }
+      })
+    }
+
+    if (roll.result === 'seven out') {
+      if (roll.betsBefore?.place?.six) {
+        memo.placeSixLosses++
+        hand.summary.placeSixLosses++
+      }
+      if (roll.betsBefore?.place?.eight) {
+        memo.placeEightLosses++
+        hand.summary.placeEightLosses++
+      }
     }
 
     return memo

--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ function playHand ({ rules, bettingStrategy, roll = rollD6 }) {
     bets = bettingStrategy({ rules, bets, hand })
     balance -= bets.new
     if (process.env.DEBUG && bets.new) console.log(`[bet] new bet $${bets.new} ($${balance})`)
+    const betsBefore = JSON.parse(JSON.stringify(bets))
     delete bets.new
 
     hand = shoot(
@@ -79,12 +80,19 @@ function playHand ({ rules, bettingStrategy, roll = rollD6 }) {
 
     bets = settle.all({ rules, bets, hand })
 
-    if (bets?.payouts?.total) {
-      balance += bets.payouts.total
-      if (process.env.DEBUG) console.log(`[payout] new payout $${bets.payouts.total} ($${balance})`)
-      delete bets.payouts
+    const payouts = bets.payouts
+    if (payouts?.total) {
+      balance += payouts.total
+      if (process.env.DEBUG) console.log(`[payout] new payout $${payouts.total} ($${balance})`)
     }
 
+    if (payouts?.ledger?.length) {
+      hand.payouts = payouts.ledger
+    }
+
+    if (payouts) delete bets.payouts
+
+    hand.betsBefore = betsBefore
     history.push(hand)
   }
 

--- a/index.test.js
+++ b/index.test.js
@@ -500,3 +500,40 @@ tap.test('integration: minPassLineMaxOdds, one hand with everything', (suite) =>
 
   suite.end()
 })
+
+tap.test('integration: placeSixEight returns payout details', (t) => {
+  let rollCount = -1
+  const fixedRolls = [
+    2, 3, // point set to 5
+    3, 3, // place 6 win
+    4, 4, // place 8 win
+    3, 4 // seven out
+  ]
+
+  function testRoll () {
+    rollCount++
+    return fixedRolls[rollCount]
+  }
+
+  const rules = {
+    minBet: 5,
+    maxOddsMultiple: {
+      4: 3,
+      5: 4,
+      6: 5,
+      8: 5,
+      9: 4,
+      10: 3
+    }
+  }
+
+  const hand = lib.playHand({ rules, roll: testRoll, bettingStrategy: betting.placeSixEight })
+
+  t.equal(hand.history[1].payouts[0].type, 'place 6 win')
+  t.equal(hand.history[2].payouts[0].type, 'place 8 win')
+  t.equal(hand.history[3].result, 'seven out')
+  t.ok(hand.history[3].betsBefore.place.six)
+  t.ok(hand.history[3].betsBefore.place.eight)
+
+  t.end()
+})


### PR DESCRIPTION
## Summary
- collect bet state and payout details in each roll
- report place bet wins/losses in hands.js
- test new payout tracking with place bets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f4eb67e4c8323b6a902731e7ae12b