### PR TITLE
Add starting balance option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ const rules = {
 }
 ```
 
+`playHand` also accepts a `balance` option to specify the starting amount for a
+hand. It defaults to `0`.
+
 For example, to make boxcars (12) a come out win instead of a loss:
 
 ```js

--- a/index.js
+++ b/index.js
@@ -53,9 +53,8 @@ function shoot (before, dice, rules = defaultRules) {
   return after
 }
 
-function playHand ({ rules, bettingStrategy, roll = rollD6 }) {
+function playHand ({ rules, bettingStrategy, roll = rollD6, balance = 0 }) {
   const history = []
-  let balance = 0
 
   let hand = {
     isComeOut: true

--- a/index.test.js
+++ b/index.test.js
@@ -537,3 +537,53 @@ tap.test('integration: placeSixEight returns payout details', (t) => {
 
   t.end()
 })
+
+tap.test('integration: starting balance is applied', (t) => {
+  let rollCount = -1
+  const fixedRolls = [
+    4, 3, // comeout win
+    5, 6, // comeout win
+    1, 1, // comeout loss
+    1, 2, // comeout loss
+    6, 6, // comeout loss
+    3, 3, // point set
+    4, 1, // neutral
+    2, 4, // point win
+    4, 4, // point set
+    3, 4 // seven out
+  ]
+
+  function testRoll () {
+    rollCount++
+    if (!fixedRolls[rollCount]) {
+      console.log('falsy return from fixed dice')
+      process.exit(1)
+    }
+    return fixedRolls[rollCount]
+  }
+
+  const rules = {
+    minBet: 5,
+    maxOddsMultiple: {
+      4: 3,
+      5: 4,
+      6: 5,
+      8: 5,
+      9: 4,
+      10: 3
+    }
+  }
+
+  const startingBalance = 50
+  const hand = lib.playHand({
+    rules,
+    roll: testRoll,
+    bettingStrategy: betting.minPassLineOnly,
+    balance: startingBalance
+  })
+
+  t.ok(Array.isArray(hand.history))
+  t.equal(hand.balance, startingBalance - 5)
+
+  t.end()
+})


### PR DESCRIPTION
## Summary
- add an optional `balance` argument to `playHand`
- document balance option in README
- test starting balance support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68539bd3b8d08323adfad7cb78dcd675