### PR TITLE
Improve Monte Carlo output

### DIFF
--- a/monte-carlo.js
+++ b/monte-carlo.js
@@ -69,8 +69,12 @@ function monteCarlo ({ trials, handsPerTrial, startingBankroll, rules }) {
 }
 
 function printResults (results) {
-  console.log('\nTrial Results')
-  console.table(results.map((r, i) => ({ trial: i + 1, balance: r.balance, rolls: r.rolls })))
+  if (results.length <= 100) {
+    console.log('\nTrial Results')
+    console.table(results.map((r, i) => ({ trial: i + 1, balance: r.balance, rolls: r.rolls })))
+  } else {
+    console.log(`\nTrial Results omitted (too many trials: ${results.length})`)
+  }
 
   console.log('\nFinal Balance Summary')
   console.table(summaryTable(results.map(r => r.balance)))


### PR DESCRIPTION
## Summary
- skip the per-trial table when running many trials to keep logs short

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685472e41b58832399e67992340cb8f3